### PR TITLE
Replaced utf8x package by utf8.

### DIFF
--- a/Vorlage/anschreiben.tex
+++ b/Vorlage/anschreiben.tex
@@ -1,5 +1,5 @@
 \documentclass[DINmtext,draft=false,ngerman]{scrlttr2}% 		DIN oder DINmtext
-\usepackage[utf8x]{inputenc}
+\usepackage[utf8]{inputenc}
 \usepackage{layouts,etoolbox}
 
 \usepackage{Vorlage_Anschreiben}

--- a/Vorlage/cv.tex
+++ b/Vorlage/cv.tex
@@ -1,7 +1,7 @@
 \PassOptionsToPackage{dvipsnames}{xcolor}
 \documentclass[12pt,a4paper,sans]{moderncv} % ***test letter***  % font size ('10pt', '11pt' and '12pt'), paper size ('a4paper', 'letterpaper', 'a5paper', 'legalpaper', 'executivepaper' and 'landscape') and font family ('sans' and 'roman')
 \usepackage[breit]{Vorlage_Lebenslauf}
-\usepackage[utf8x]{inputenc}
+\usepackage[utf8]{inputenc}
 %\usepackage{showframe}
 %\PrerenderUnicode{ßÄäÜüÖö}
 


### PR DESCRIPTION
For the Latex versions I use, utf8x is no longer available. 'Bewerbung_Komplett.tex', 'Bewerbung_Einzeln.tex' and 'anhang.tex' already refer to the utf8 package and I think so should 'anschreiben.tex' and 'cv.tex'.